### PR TITLE
lazy require node-sass to avoid initialization conflict with sass-loader

### DIFF
--- a/src/parse-variables.js
+++ b/src/parse-variables.js
@@ -1,4 +1,3 @@
-import sass from 'node-sass';
 import camelCase from 'lodash.camelcase';
 
 function constructSassString(variables) {
@@ -13,7 +12,7 @@ function constructSassString(variables) {
 }
 
 export default function parseVariables(variables, opts = {}) {
-  const result = sass.renderSync({
+  const result = require('node-sass').renderSync({ // eslint-disable-line global-require
     data: constructSassString(variables),
     outputStyle: 'compact',
   }).css.toString();


### PR DESCRIPTION
Our team has been intermittently running into this issue while running alongside sass-loader:

webpack-contrib/sass-loader#352

```shell
undefined:0
TypeError: undefined is not a function
```

The process hangs indefinitely after this. Here is our usage of the two loaders, with webpack@2.2.0:

```js
import themeVariables from '!!sass-variable-loader!../theme/variables.scss';
import '!style-loader!css-loader!sass-loader!../theme/main.scss';
```

The two files do not import from one other.

Today the problem started happening for every build, so I dug in and tried to find a workaround. Moving the import/require of node-sass into the parseVariables function body appears to clear up the contention. I have no solid reason as to why this is working, but it seems that node-sass is unable to deal with simultaneous requires, and the lazy resolution provides just enough delay to avoid this.

I realize this is not a lot to go on, but I am happy to provide more information and examples.